### PR TITLE
Fix --mptcp on kernels with mainlined MPTCP.

### DIFF
--- a/src/netutils.h
+++ b/src/netutils.h
@@ -60,11 +60,13 @@ typedef struct {
     char *port;
 } ss_addr_t;
 
+#ifndef IPPROTO_MPTCP
 /* MPTCP_ENABLED setsockopt values for kernel 4 & 3, best behaviour to be independant of kernel version is to test from newest to the latest values */
 #ifndef MPTCP_ENABLED
 static const char mptcp_enabled_values[] = { 42, 26, 0 };
 #else
 static const char mptcp_enabled_values[] = { MPTCP_ENABLED, 0 };
+#endif
 #endif
 
 #ifndef UPDATE_INTERVAL

--- a/src/redir.c
+++ b/src/redir.c
@@ -770,7 +770,13 @@ accept_cb(EV_P_ ev_io *w, int revents)
     int index                    = rand() % listener->remote_num;
     struct sockaddr *remote_addr = listener->remote_addr[index];
 
-    int remotefd = socket(remote_addr->sa_family, SOCK_STREAM, IPPROTO_TCP);
+    int protocol = IPPROTO_TCP;
+#ifdef IPPROTO_MPTCP
+    if (listener->mptcp > 0) {
+	protocol = IPPROTO_MPTCP;
+    }
+#endif
+    int remotefd = socket(remote_addr->sa_family, SOCK_STREAM, protocol);
     if (remotefd == -1) {
         ERROR("socket");
         return;
@@ -808,6 +814,7 @@ accept_cb(EV_P_ ev_io *w, int revents)
 #endif
     }
 
+#ifndef IPPROTO_MPTCP
     // Enable MPTCP
     if (listener->mptcp > 1) {
         int err = setsockopt(remotefd, SOL_TCP, listener->mptcp, &opt, sizeof(opt));
@@ -827,6 +834,7 @@ accept_cb(EV_P_ ev_io *w, int revents)
             ERROR("failed to enable multipath TCP");
         }
     }
+#endif
 
     if (tcp_outgoing_sndbuf > 0) {
         setsockopt(remotefd, SOL_SOCKET, SO_SNDBUF, &tcp_outgoing_sndbuf, sizeof(int));

--- a/src/server.c
+++ b/src/server.c
@@ -594,7 +594,13 @@ create_and_bind(const char *host, const char *port, int mptcp)
     }
 
     for (/*rp = result*/; rp != NULL; rp = rp->ai_next) {
-        listen_sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        int protocol = rp->ai_protocol;
+#ifdef IPPROTO_MPTCP
+        if (mptcp == 1) {
+            protocol = IPPROTO_MPTCP;
+        }
+#endif
+        listen_sock = socket(rp->ai_family, rp->ai_socktype, protocol);
         if (listen_sock == -1) {
             continue;
         }
@@ -616,6 +622,7 @@ create_and_bind(const char *host, const char *port, int mptcp)
             }
         }
 
+#ifndef IPPROTO_MPTCP
         if (mptcp == 1) {
             int i = 0;
             while ((mptcp = mptcp_enabled_values[i]) > 0) {
@@ -629,6 +636,7 @@ create_and_bind(const char *host, const char *port, int mptcp)
                 ERROR("failed to enable multipath TCP");
             }
         }
+#endif
 
         s = bind(listen_sock, rp->ai_addr, rp->ai_addrlen);
         if (s == 0) {


### PR DESCRIPTION
Mainlined MPTCP on Linux 5.6+ is enabled with IPPROTO_MPTCP rather than setsockopt.